### PR TITLE
revert dplv2 changes to deployment section of travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,10 +23,10 @@ before_deploy:
   - make set_version
 deploy:
   provider: pypi
-  username: $PYPI_USERNAME
+  user: $PYPI_USERNAME
   password: $PYPI_PASSWORD
   distributions: "sdist bdist_wheel"
-  cleanup: false
+  skip_cleanup: true
   on:
     branch: master
     tags: true


### PR DESCRIPTION
I was moving too fast and misunderstood the banner on travis-ci around dplv2. There were changes to travis.yml fields but dplv1 (specifically concerning the deployment section of travis.yml) is still default, I shouldn't have updated the deploy section. 

reverting those. 